### PR TITLE
* Aktualizacja  podpunktu związanego z uzupełnianiem pola NICK IC oraz dodanie nowego podpunktu dot. piractwa

### DIFF
--- a/dokumenty/regulamin.md
+++ b/dokumenty/regulamin.md
@@ -9,7 +9,7 @@
 * Treści widoczne na forum, regulaminy, działy są ujęte prawami autorskimi.
 * Treści, które mają na celu promocję innych projektów są surowo zabronione.
 * Za czyny, które nie zostały wymienione w punktach regulaminu decyzję o ukaraniu użytkownika (i jego karze) podejmuje moderator za zgodą Administratora Forum.
-* Użytkownik jest zobowiązany do uzupełnienia pełnymi danymi z serwera gry SA-MP jakim jest Mrucznik Role Play (samp.mrucznik-rp.pl), pod polem [Nick IC]. Oszustwa są surowo zabronione i karane.
+* Użytkownik jest zobowiązany do uzupełnienia pełnymi danymi z serwera gry SA-MP jakim jest Mrucznik Role Play (samp.mrucznik-rp.pl), pod polem [Nick IC]. W przypadku braku/bezczynności konta na serwerze pole zostawiamy puste (warunek bezczynności konta to brak umieszczonych skarg/apelacji/tematów na forum związanych z kontem na serwerze w przeciągu 6 miesięcy). Oszustwa są surowo zabronione i karane.
 
 ## Korzystanie z forum Mrucznik Role Play
 * Na forum www.mrucznik-rp.pl, z jednego konta globalnego może korzystać tylko i wyłącznie jedna osoba, zabrania się udostępniania konta globalnego dla osób trzecich, podawania danych do logowania na stronę WWW. Zabrania się również tworzenia multikont na forum. Jeśli przypadkiem jest współdzielenie swojego łącza internetowego, dany użytkownik jest zobowiązany do zgłoszenia takiego czynu w specjalnym temacie. (Przejdź do tematu). Za brak wpisu w temacie o współdzieleniu łącza, karą może być nawet odcięcie od dostępu do forum.

--- a/dokumenty/regulamin.md
+++ b/dokumenty/regulamin.md
@@ -23,6 +23,7 @@
 * Nadmierne używanie słów wulgarnych, wyzwiska, hejt, trollowanie - skutkuje karą nadaną przez moderatora. W powyższe punkty wchodzą rzeczy takie jak prywatne wiadomości, statusy, posty, tematy, panel gracza. Karze podlega zarówno osoba, która wykonuje powyższe czyny oraz ta, która wdaje się w działania, oraz też nakłania do działań.
 * Zakazuje się umieszczanie ofert handlowych, linków w celach zarobkowych na całym forum, karą może być nawet odcięcie od dostępu do serwera SA-MP oraz forum.
 * Nazwa użytkownika nie może być wulgarna i w żaden sposób prowokacyjna, zastrzega się również błędów ortograficznych.
+* Forum nie wspiera piractwa, tym samym zakazuje się publikacji odnośników do stron zawierających oprogramowanie pirackie lub łamiące zabezpieczenia.
 * Na forum obowiązuje zakaz publikacji cudzych zdjęć i danych osobowych bez zgody osoby której dotyczą.
 
 ## Prawa moderatora.


### PR DESCRIPTION

1. **NICK IC**

Dużo osób dostaje upomnienie słowne za to, że nie mają poprawnie uzupełnionego pola. Co w przypadku gdy gracz już nie gra lub nie ma konta na serwerze? Do tej pory regulamin forum nie odpowiadał na to pytanie. To jest moja propozycja co do aktualizacji tego podpunktu. Oczywiście można dopisać coś więcej lub całkiem przebudować ten podpunkt.

Nadajemy upomnienia słowne wtedy, kiedy jest złamany warunek bezczynności konta.

2. **PIRACTWO**

Rzecz chyba oczywista. Często ukrywamy statusy lub karamy za linki z torrentów np. do gta sa. Dla niektórych osób nie jest to oczywiste i nie mają o tym pojęcia. Należy dodać ten podpunkt, żeby było wszystko jasne.

Moja sugestia co do nowego podpunktu, jeżeli macie własne definicje tego punktu to zapraszam do komentowania.
